### PR TITLE
Use correct field to access team names

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -20,7 +20,7 @@ func uniqueOwners(owners []codeowners.Owner) []codeowners.Owner {
 
 func hasTeamOwnerSufficientPermission(teams []*github.Team, name string) bool {
 	for _, team := range teams {
-		if (stringify(team.Name) == name) && !team.Permissions[pushPermission] {
+		if (stringify(team.Slug) == name) && !team.Permissions[pushPermission] {
 			return false
 		}
 	}
@@ -29,7 +29,7 @@ func hasTeamOwnerSufficientPermission(teams []*github.Team, name string) bool {
 
 func hasUserOwnerSufficientPermission(collaborators []*github.User, name string) bool {
 	for _, collaborator := range collaborators {
-		if (stringify(collaborator.Name) == name) && !collaborator.Permissions[pushPermission] {
+		if (stringify(collaborator.Login) == name) && !collaborator.Permissions[pushPermission] {
 			return false
 		}
 	}

--- a/testdata/CODEOWNERS
+++ b/testdata/CODEOWNERS
@@ -24,6 +24,8 @@
 # the octocats team in the octo-org organization owns all .txt files.
 *.txt @octo-org/octocats
 
+* @octo-org/octocats-admins
+
 # In this example, @doctocat owns any files in the build/logs
 # directory at the root of the repository and any of its
 # subdirectories.


### PR DESCRIPTION
## Background
- codeownerizer makes API requests to grant a push permission for teams that is already granted the permission
- Algorighm
  1. codeownerizer list up teams in our organization via API
  2. It also list up owners in CODEOWNERS, which should have push permissions
  3. For each combination of teams (step i) and owners (step ii), if they have the same name and the team does not have appropriate permission, make API request to grant the permission

## Solution
- Use `github.Team.Slug` to match an owner in CODEOWNERS and team information got from GitHub API (step iii above)
  - `github.Team.Name` is used before
    - Canonical team name is written in CODEOWNERS like `service-platform-admins`
    - API response for team list has `Name` like "Service Platform Admins" and `Slug` like `service-platform-admins`
    - To properly match name in CODEOWNERS, we should refer `Slug` in API response
- This should avoid redundant API request
  - codeownerizer can make API requests for only teams newly added to CODEOWNERS
    - This leads to resolving rate limit

## Supplemental Information
API response to list up teams in our organization (print as Golang struct, omitted unrelated fields)
```
github.Team{Name:"Service Platform Admins", Slug:"service-platform-admins", Permission:"push",  Permissions:map[admin:false maintain:false pull:true push:true triage:true]}
```

## Links
- https://moneyforward.atlassian.net/browse/SP-884